### PR TITLE
Back button consistency

### DIFF
--- a/src/main/java/dev/sefiraat/sefilib/slimefun/itemgroup/SimpleFlexGroup.java
+++ b/src/main/java/dev/sefiraat/sefilib/slimefun/itemgroup/SimpleFlexGroup.java
@@ -197,7 +197,8 @@ public class SimpleFlexGroup extends FlexItemGroup {
             GUIDE_BACK,
             ChestMenuUtils.getBackButton(
                 player,
-                "&7" + Slimefun.getLocalization().getMessage(player, "guide.back.guide")
+                "",
+                ChatColor.GRAY + Slimefun.getLocalization().getMessage(player, "guide.back.guide")
             )
         );
         menu.addMenuClickHandler(GUIDE_BACK, (p, slot, itemStack, clickAction) -> {


### PR DESCRIPTION
Recreated a PR to replace #8.
The color of back button is fixed in #9, but there is an empty line before the lore in Slimefun.